### PR TITLE
Update deploy documentation to include required permissions and events

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -10,4 +10,4 @@ This app requires these **Permissions & events** for the GitHub App:
 - Commit statuses - **Read & Write**
   - [x] Check the box for **Status** events
 - Single File - **Read-only**
-  - Path: `required-labels.yml`
+  - Path: `.github/required-labels.yml`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,4 +4,8 @@ If you would like to run your own instance of this app, see the [docs for deploy
 
 This app requires these **Permissions & events** for the GitHub App:
 
-> **TODO**: List permissions required for deployment here. See [probot/stale](https://github.com/probot/stale/blob/master/docs/deploy.md) for an example.
+- Pull requests - **Read & Write**
+  - [x] Check the box for **Pull request** events
+- Repository webhooks - **Read-only**
+- Commit statuses - **Read & Write**
+  - [x] Check the box for **Status** events

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -9,3 +9,5 @@ This app requires these **Permissions & events** for the GitHub App:
 - Repository webhooks - **Read-only**
 - Commit statuses - **Read & Write**
   - [x] Check the box for **Status** events
+- Single File - **Read-only**
+  - Path: `required-labels.yml`


### PR DESCRIPTION
Add the necessary permissions required for this Probot to the `deploy.md` documentation.